### PR TITLE
Move Logic for Pieces model

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -6,8 +6,6 @@ class Knight < Piece
     moved?(x,y) && l_shaped_move?(x,y)
   end
 
-  private
-
   # Returns true if the coordinates provided are either
   # 2 tiles away from the x_position along the x_axis and
   # 1 tile away from the y_position along the y_axis OR 1 tile

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -8,8 +8,8 @@ class Pawn < Piece
     first_move? ? first_forward_move?(x,y) : forward_move?(x,y)
   end
 
-  # Mutates the type of the piece from Pawn
-  # to the new type provided.
+  # Updates the piece's type from Pawn to the new type
+  # provided.
   def promote! (new_type)
     options = ["Bishop", "Knight", "Queen", "Rook"]
     raise ArgumentError unless options.include?(new_type)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -5,16 +5,16 @@ class Piece < ActiveRecord::Base
   validates :color, inclusion: { in: %w(black white) }
   validates :type, inclusion: { in: %w(Pawn Rook Bishop Knight King Queen) }
 
-  # Returns "valid" and updates the piece's x and
+  # Returns true and updates the piece's x and
   # y position to provided coordinates if move is valid,
-  # otherwise do nothing and return nil.
-  def move(x,y)
+  # otherwise do nothing and return false.
+  def move!(x,y)
     if valid_move?(x,y)
       self.x_position = x
       self.y_position = y
-      return "valid"
+      return true
     else
-      return nil
+      return false
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -5,6 +5,19 @@ class Piece < ActiveRecord::Base
   validates :color, inclusion: { in: %w(black white) }
   validates :type, inclusion: { in: %w(Pawn Rook Bishop Knight King Queen) }
 
+  # Returns "valid" and updates the piece's x and
+  # y position to provided coordinates if move is valid,
+  # otherwise do nothing and return nil.
+  def move(x,y)
+    if valid_move?(x,y)
+      self.x_position = x
+      self.y_position = y
+      return "valid"
+    else
+      return nil
+    end
+  end
+
   # All validation assumes white player is on the
   # 6-7 rows of the array, and black player is on
   # 0-1 rows of the array.

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Bishop, type: :model do
       expect(bishop.y_position).to eq 6
     end
 
-    it "should return 'nil' and not update the bishop's position when it makes an invalid move" do
+    it "should return nil and not update the bishop's position when it makes an invalid move" do
       bishop = FactoryGirl.create(:bishop, :black)
       expect(bishop.move(3,0)).to eq nil
       expect(bishop.x_position).to eq 2

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -73,16 +73,16 @@ RSpec.describe Bishop, type: :model do
 
   describe "bishop move method" do
 
-    it "should return 'valid' and update the bishop's position when it makes a valid move" do
+    it "should return true and update the bishop's position when it makes a valid move" do
       bishop = FactoryGirl.create(:bishop, :white)
-      expect(bishop.move(3,6)).to eq "valid"
+      expect(bishop.move!(3,6)).to eq true
       expect(bishop.x_position).to eq 3
       expect(bishop.y_position).to eq 6
     end
 
     it "should return nil and not update the bishop's position when it makes an invalid move" do
       bishop = FactoryGirl.create(:bishop, :black)
-      expect(bishop.move(3,0)).to eq nil
+      expect(bishop.move!(3,0)).to eq false
       expect(bishop.x_position).to eq 2
       expect(bishop.y_position).to eq 0
     end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe Bishop, type: :model do
     end
   end
 
-
-  describe "Bishop creation validation" do
+  describe "bishop creation validation" do
 
     it "should have a type of Bishop" do
       r = FactoryGirl.create(:bishop, color: 'white')
@@ -70,6 +69,24 @@ RSpec.describe Bishop, type: :model do
     it "should not be allowed to create a red bishop" do
       expect { FactoryGirl.create(:bishop, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "bishop move method" do
+
+    it "should return 'valid' and update the bishop's position when it makes a valid move" do
+      bishop = FactoryGirl.create(:bishop, :white)
+      expect(bishop.move(3,6)).to eq "valid"
+      expect(bishop.x_position).to eq 3
+      expect(bishop.y_position).to eq 6
+    end
+
+    it "should return 'nil' and not update the bishop's position when it makes an invalid move" do
+      bishop = FactoryGirl.create(:bishop, :black)
+      expect(bishop.move(3,0)).to eq nil
+      expect(bishop.x_position).to eq 2
+      expect(bishop.y_position).to eq 0
+    end
+
   end
 
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -83,16 +83,16 @@ RSpec.describe King, type: :model do
 
   describe "king move method" do
 
-    it "should return 'valid' and update the king's position when it makes a valid move" do
+    it "should return true and update the king's position when it makes a valid move" do
       king = FactoryGirl.create(:king, :white)
-      expect(king.move(4,6)).to eq "valid"
+      expect(king.move!(4,6)).to eq true
       expect(king.x_position).to eq 4
       expect(king.y_position).to eq 6
     end
 
     it "should return nil and not update the king's position when it makes an invalid move" do
       king = FactoryGirl.create(:king, :black)
-      expect(king.move(5,0)).to eq nil
+      expect(king.move!(5,0)).to eq false
       expect(king.x_position).to eq 3
       expect(king.y_position).to eq 0
     end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe King, type: :model do
       expect(king.y_position).to eq 6
     end
 
-    it "should return 'nil' and not update the king's position when it makes an invalid move" do
+    it "should return nil and not update the king's position when it makes an invalid move" do
       king = FactoryGirl.create(:king, :black)
       expect(king.move(5,0)).to eq nil
       expect(king.x_position).to eq 3

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe King, type: :model do
     end
   end
 
-  describe "King" do
+  describe "king creation validation" do
 
     it "should have a type of King" do
       r = FactoryGirl.create(:king, color: 'white')
@@ -79,6 +79,24 @@ RSpec.describe King, type: :model do
     it "should not be allowed to create a red king" do
       expect { FactoryGirl.create(:king, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "king move method" do
+
+    it "should return 'valid' and update the king's position when it makes a valid move" do
+      king = FactoryGirl.create(:king, :white)
+      expect(king.move(4,6)).to eq "valid"
+      expect(king.x_position).to eq 4
+      expect(king.y_position).to eq 6
+    end
+
+    it "should return 'nil' and not update the king's position when it makes an invalid move" do
+      king = FactoryGirl.create(:king, :black)
+      expect(king.move(5,0)).to eq nil
+      expect(king.x_position).to eq 3
+      expect(king.y_position).to eq 0
+    end
+
   end
 
 end

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Knight, type: :model do
       expect(knight.y_position).to eq 6
     end
 
-    it "should return 'nil' and not update the knight's position when it makes an invalid move" do
+    it "should return nil and not update the knight's position when it makes an invalid move" do
       knight = FactoryGirl.create(:knight, :black)
       expect(knight.move(3,0)).to eq nil
       expect(knight.x_position).to eq 1

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Knight, type: :model do
     end
   end
 
-  describe "Knight creation validation" do
+  describe "knight creation validation" do
 
     it "should have a type of Knight" do
       r = FactoryGirl.create(:knight, color: 'white')
@@ -79,6 +79,24 @@ RSpec.describe Knight, type: :model do
     it "should not be allowed to create a red knight" do
       expect { FactoryGirl.create(:knight, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "knight move method" do
+
+    it "should return 'valid' and update the knight's position when it makes a valid move" do
+      knight = FactoryGirl.create(:knight, :white)
+      expect(knight.move(3,6)).to eq "valid"
+      expect(knight.x_position).to eq 3
+      expect(knight.y_position).to eq 6
+    end
+
+    it "should return 'nil' and not update the knight's position when it makes an invalid move" do
+      knight = FactoryGirl.create(:knight, :black)
+      expect(knight.move(3,0)).to eq nil
+      expect(knight.x_position).to eq 1
+      expect(knight.y_position).to eq 0
+    end
+
   end
 
 end

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -83,16 +83,16 @@ RSpec.describe Knight, type: :model do
 
   describe "knight move method" do
 
-    it "should return 'valid' and update the knight's position when it makes a valid move" do
+    it "should return true and update the knight's position when it makes a valid move" do
       knight = FactoryGirl.create(:knight, :white)
-      expect(knight.move(3,6)).to eq "valid"
+      expect(knight.move!(3,6)).to eq true
       expect(knight.x_position).to eq 3
       expect(knight.y_position).to eq 6
     end
 
     it "should return nil and not update the knight's position when it makes an invalid move" do
       knight = FactoryGirl.create(:knight, :black)
-      expect(knight.move(3,0)).to eq nil
+      expect(knight.move!(3,0)).to eq false
       expect(knight.x_position).to eq 1
       expect(knight.y_position).to eq 0
     end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -93,16 +93,16 @@ RSpec.describe Pawn, type: :model do
 
   describe "pawn move method" do
 
-    it "should return 'valid' and update the pawn's position when it makes a valid move" do
+    it "should return true and update the pawn's position when it makes a valid move" do
       pawn = FactoryGirl.create(:pawn, :white)
-      expect(pawn.move(5,5)).to eq "valid"
+      expect(pawn.move!(5,5)).to eq true
       expect(pawn.x_position).to eq 5
       expect(pawn.y_position).to eq 5
     end
 
     it "should return nil and not update the pawn's position when it makes an invalid move" do
       pawn = FactoryGirl.create(:pawn, :black)
-      expect(pawn.move(5,0)).to eq nil
+      expect(pawn.move!(5,0)).to eq false
       expect(pawn.x_position).to eq 5
       expect(pawn.y_position).to eq 1
     end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Pawn, type: :model do
     end
   end
 
-  describe "Pawn creation validation" do
+  describe "pawn creation validation" do
 
     it "should have a type of Pawn" do
       r = FactoryGirl.create(:pawn, color: 'white')
@@ -89,6 +89,24 @@ RSpec.describe Pawn, type: :model do
     it "should not be allowed to create a red pawn" do
       expect { FactoryGirl.create(:pawn, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "pawn move method" do
+
+    it "should return 'valid' and update the pawn's position when it makes a valid move" do
+      pawn = FactoryGirl.create(:pawn, :white)
+      expect(pawn.move(5,5)).to eq "valid"
+      expect(pawn.x_position).to eq 5
+      expect(pawn.y_position).to eq 5
+    end
+
+    it "should return 'nil' and not update the pawn's position when it makes an invalid move" do
+      pawn = FactoryGirl.create(:pawn, :black)
+      expect(pawn.move(5,0)).to eq nil
+      expect(pawn.x_position).to eq 5
+      expect(pawn.y_position).to eq 1
+    end
+
   end
 
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.y_position).to eq 5
     end
 
-    it "should return 'nil' and not update the pawn's position when it makes an invalid move" do
+    it "should return nil and not update the pawn's position when it makes an invalid move" do
       pawn = FactoryGirl.create(:pawn, :black)
       expect(pawn.move(5,0)).to eq nil
       expect(pawn.x_position).to eq 5

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -103,16 +103,16 @@ RSpec.describe Queen, type: :model do
 
   describe "queen move method" do
 
-    it "should return 'valid' and update the queen's position when it makes a valid move" do
+    it "should return true and update the queen's position when it makes a valid move" do
       queen = FactoryGirl.create(:queen, :white)
-      expect(queen.move(7,7)).to eq "valid"
+      expect(queen.move!(7,7)).to eq true
       expect(queen.x_position).to eq 7
       expect(queen.y_position).to eq 7
     end
 
     it "should return nil and not update the queen's position when it makes an invalid move" do
       queen = FactoryGirl.create(:queen, :black)
-      expect(queen.move(3,7)).to eq nil
+      expect(queen.move!(3,7)).to eq false
       expect(queen.x_position).to eq 4
       expect(queen.y_position).to eq 0
     end

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Queen, type: :model do
       expect(queen.y_position).to eq 7
     end
 
-    it "should return 'nil' and not update the queen's position when it makes an invalid move" do
+    it "should return nil and not update the queen's position when it makes an invalid move" do
       queen = FactoryGirl.create(:queen, :black)
       expect(queen.move(3,7)).to eq nil
       expect(queen.x_position).to eq 4

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Queen, type: :model do
     end
   end
 
-  describe "Queen creation validation" do
+  describe "queen creation validation" do
 
     it "should have a type of Queen" do
       r = FactoryGirl.create(:queen, color: 'white')
@@ -99,6 +99,24 @@ RSpec.describe Queen, type: :model do
     it "should not be allowed to create a red queen" do
       expect { FactoryGirl.create(:queen, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "queen move method" do
+
+    it "should return 'valid' and update the queen's position when it makes a valid move" do
+      queen = FactoryGirl.create(:queen, :white)
+      expect(queen.move(7,7)).to eq "valid"
+      expect(queen.x_position).to eq 7
+      expect(queen.y_position).to eq 7
+    end
+
+    it "should return 'nil' and not update the queen's position when it makes an invalid move" do
+      queen = FactoryGirl.create(:queen, :black)
+      expect(queen.move(3,7)).to eq nil
+      expect(queen.x_position).to eq 4
+      expect(queen.y_position).to eq 0
+    end
+
   end
 
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Rook, type: :model do
     end
   end
 
-  describe "Rook creation validation" do
+  describe "rook creation validation" do
     it "should have a type of Rook" do
       r = FactoryGirl.create(:rook, color: 'white')
       expect(r.type).to eq("Rook")
@@ -58,6 +58,24 @@ RSpec.describe Rook, type: :model do
     it "should not be allowed to create a red rook" do
       expect { FactoryGirl.create(:rook, color: "red") }.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe "rook move method" do
+
+    it "should return 'valid' and update the rook's position when it makes a valid move" do
+      rook = FactoryGirl.create(:rook, :white)
+      expect(rook.move(0,7)).to eq "valid"
+      expect(rook.x_position).to eq 0
+      expect(rook.y_position).to eq 7
+    end
+
+    it "should return 'nil' and not update the rook's position when it makes an invalid move" do
+      rook = FactoryGirl.create(:rook, :black)
+      expect(rook.move(3,7)).to eq nil
+      expect(rook.x_position).to eq 0
+      expect(rook.y_position).to eq 0
+    end
+
   end
 
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -62,16 +62,16 @@ RSpec.describe Rook, type: :model do
 
   describe "rook move method" do
 
-    it "should return 'valid' and update the rook's position when it makes a valid move" do
+    it "should return true and update the rook's position when it makes a valid move" do
       rook = FactoryGirl.create(:rook, :white)
-      expect(rook.move(0,7)).to eq "valid"
+      expect(rook.move!(0,7)).to eq true
       expect(rook.x_position).to eq 0
       expect(rook.y_position).to eq 7
     end
 
     it "should return nil and not update the rook's position when it makes an invalid move" do
       rook = FactoryGirl.create(:rook, :black)
-      expect(rook.move(3,7)).to eq nil
+      expect(rook.move!(3,7)).to eq false
       expect(rook.x_position).to eq 0
       expect(rook.y_position).to eq 0
     end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Rook, type: :model do
       expect(rook.y_position).to eq 7
     end
 
-    it "should return 'nil' and not update the rook's position when it makes an invalid move" do
+    it "should return nil and not update the rook's position when it makes an invalid move" do
       rook = FactoryGirl.create(:rook, :black)
       expect(rook.move(3,7)).to eq nil
       expect(rook.x_position).to eq 0


### PR DESCRIPTION
Implemented move logic for Pieces.model which is inherited by all subpieces and provided a block comment to explain functionality.  Included rspec tests for valid and invalid moves for all subpieces.