### PR TITLE
Bug Fix - Boolean Flag Defaults

### DIFF
--- a/db/migrate/20160802123746_change_default_flags_for_boolean.rb
+++ b/db/migrate/20160802123746_change_default_flags_for_boolean.rb
@@ -1,0 +1,6 @@
+class ChangeDefaultFlagsForBoolean < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :pieces, :captured, from: nil, to: false
+    change_column_default :pieces, :checkmate, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726151316) do
+ActiveRecord::Schema.define(version: 20160802123746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,17 +27,17 @@ ActiveRecord::Schema.define(version: 20160726151316) do
   end
 
   create_table "pieces", force: :cascade do |t|
-    t.string   "color",      limit: 255
-    t.string   "type",       limit: 255
+    t.string   "color"
+    t.string   "type"
     t.integer  "x_position"
     t.integer  "y_position"
     t.integer  "game_id"
     t.integer  "player_id"
-    t.boolean  "captured"
-    t.boolean  "checkmate"
+    t.boolean  "captured",   default: false
+    t.boolean  "checkmate",  default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "moved",                  default: false
+    t.boolean  "moved",      default: false
   end
 
   create_table "players", force: :cascade do |t|

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Piece, type: :model do
       victim.reload
       expect(victim.x_position).to eq 3
       expect(victim.y_position).to eq 6
-      expect(victim.captured).to eq nil
+      expect(victim.captured).to eq false
     end
   end
 end


### PR DESCRIPTION
I noticed while implementing the capture/obstruction logic that the default for the captured flag was not set so that I had to check for nil instead of false.  I went in and changed the default values for the captured and the other boolean flag in our database already, checkmate, to default of false, as that is what we'd expect from a boolean, not nil.

Updated the rspec for capture logic to properly reflect this.